### PR TITLE
pirateproxy.wtf bypass

### DIFF
--- a/injection_script.js
+++ b/injection_script.js
@@ -680,6 +680,17 @@ domainBypass("chaosity.cheatsquad.gg",()=>{
 	})
 	ensureDomLoaded(()=>document.querySelectorAll("div.loader").forEach(d=>d.className="check_loader"))
 })
+
+// pirateproxy.wtf bypass
+// example url: https://pirateproxy.wtf/?mypiratebay.net
+hrefBypass(/pirateproxy.wtf\/\?/, () => {
+    var splitted = document.URL.split("?")
+    
+    if (splitted.length === 2) {
+        safelyNavigate("https://" + splitted[1])
+    }
+})
+
 //Insertion point for bypasses running before the DOM is loaded.
 domainBypass(/^((www\.)?((njiir|healthykk|linkasm|dxdrive|getwallpapers|sammobile|ydfile)\.com|punchsubs\.net|k2s\.cc|muhammadyoga\.me|u\.to|skiplink\.io|(uploadfree|freeupload)\.info|fstore\.biz))$/,()=>window.setInterval=f=>setInterval(f,1))
 hrefBypass(/firefaucet\.win\/l\/|sfirmware\.com\/downloads-file\/|(apkily\.com\/getapp$)|androidtop\.net\/\?do=downloads\&id=/,()=>window.setInterval=f=>setInterval(f,1))


### PR DESCRIPTION
Visit https://pirateproxy.wtf/ and click on a link. Navigation is delayed between a ~10 seconds ad wall.
This takes target's address from url (placed after the question mark) and safely navigates to it.

Please comment if code style is wrong.