### PR TITLE
Take out the \n from the message file

### DIFF
--- a/_locales/pt-BR/messages.json
+++ b/_locales/pt-BR/messages.json
@@ -108,7 +108,7 @@
 		"message": "Você está sendo redirecionado para %"
 	},
 	"infoLinkvertise": {
-		"message": "Não nos é permitido contornar este site, mas negociamos a eliminação dos seus passos mais incômodos.\n"
+		"message": "Não nos é permitido contornar este site, mas negociamos a eliminação dos seus passos mais incômodos."
 	},
 	"infoFileHoster": {
 		"message": "Infelizmente, o servidor de download irá garantir que você esperou antes de lhe permitir baixar o arquivo"


### PR DESCRIPTION
The \n creates an "unclosed string" / "unterminated string literal" error when parsing the javascript file.