### PR TITLE
Take out \n of message.json

### DIFF
--- a/_locales/pt-PT/messages.json
+++ b/_locales/pt-PT/messages.json
@@ -108,7 +108,7 @@
 		"message": "Você será navegado até %."
 	},
 	"infoLinkvertise": {
-		"message": "Não nos é permitido contornar este site, mas negociámos a eliminação dos seus passos mais incómodos.\n"
+		"message": "Não nos é permitido contornar este site, mas negociámos a eliminação dos seus passos mais incómodos."
 	},
 	"infoFileHoster": {
 		"message": "Infelizmente, o servidor de download irá garantir que você esperou antes de permitir que você faça o download do arquivo."


### PR DESCRIPTION
The \n creates an "unclosed string" / "unterminated string literal" error when parsing the javascript file.