### PR TITLE
Add copydev.com bypass (resolve #1621)

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -198,7 +198,8 @@
 	"param_go_hex": [
 		"*://*.zflas.com/*?go=*",
 		"*://*.365myoffice.com/?go=*",
-		"*://*.shiroyasha.me/?go=*"
+		"*://*.shiroyasha.me/?go=*",
+		"*://*.copydev.com/?go=*"
 	],
 	"param_to_base64": [
 		"*://*.beermoneyforum.com/redirect?*",


### PR DESCRIPTION
href.li is used for removing referrers in the issue mentioned.