### PR TITLE
Fix brcheats.net bypass

### DIFF
--- a/injection_script.js
+++ b/injection_script.js
@@ -1505,6 +1505,10 @@ ensureDomLoaded(()=>{
 		awaitElement("a#linkarq[href]",safelyAssign)
 		awaitElement("a#botao2[href]",safelyAssign)
 	})
+	domainBypass("mundofinanceiro.club",()=>{
+		awaitElement("a#linkarq[href]",safelyAssign)
+		awaitElement("a#botao2[href]",safelyAssign)
+	})
 	domainBypass("apkhubs.com",()=>ifElement("a#downloadbtn",a=>{
 		countdown(0)
 		safelyNavigate(a.href)


### PR DESCRIPTION
The site "mundofinanceiro.club" receives the reffererlink "dash.brcheats.net" and redirects to the specified page after performing the necessary actions (at the moment it is informed to click on the advertisement and wait 20 seconds on the advertiser's page, being that it really is just a timer in the background counting for 20 seconds in the variables "segundos" and "timeleft", which by a command in jQuery makes the elements visible as soon as it reaches "0".

To be able to view the specific pages it is necessary to register at "BRCheats.net" and go to the options "Download" and "Recarregar" (The site is entirely in Brazilian Portuguese) and then go to "Downloads>Loader" and "Tempo de VIP>Recarregar VIP", so you get to destinations.

You can also see them via "http://tudohost.xyz/public/R_Mundo/?src=aHR0cHM6Ly9kYXNoLmJyY2hlYXRzLm5ldC8/cGFnZT1yZWNhcnJlZ2Fy" that will redirect you to the pages.

Translated with Google Translator :/