### PR TITLE
Remove rule for googlebot

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -214,7 +214,6 @@
 		"*://caraterbaik.my.id/?data=*",
 		"*://safe2.wisatamu.my.id/?data=*"
 	],
-	"useragent_googlebot": [],
 	"useragent_chrome": [
 		"*://*.fluxteam.xyz/*"
 	],


### PR DESCRIPTION
Issue with this extension is causing immediate issues (#1707 #1704 #1706 #1703 #1708) for many of my sites users, so I figured I'd try this. **Not sure if this works** and if there are checks which require this key to exist - just pushing an urgent potential solution.

Obviously the problem is only present when this filter is an empty array, a more thorough solution would be to solve the actual check for the rule, I suspect somewhere in background.js