### PR TITLE
Add bypass for acortame.xyz

### DIFF
--- a/injection_script.js
+++ b/injection_script.js
@@ -1724,6 +1724,9 @@ ensureDomLoaded(()=>{
 			}
 		}
 	})
+	domainBypass("acortame.xyz", () => {
+		safelyNavigate("https://acortame.xyz?redir=" + atob(atob(atob(atob(Lnk)))))
+	})
 	//Insertion point for domain-or-href-specific bypasses running after the DOM is loaded. Bypasses here will no longer need to call ensureDomLoaded.
 	if(bypassed)
 	{


### PR DESCRIPTION
This bypasses `acortame.xyz` URLs. This bypass is appliable to some other domains which have the same javascript stuff and frontend but I honestly don't remember their domain names now. Add those domains if you happen to find them, I will try it too.